### PR TITLE
Add methods to create default serializer and deserializer

### DIFF
--- a/Packages/UGF.Yaml/Runtime/Plugins/YamlDotNet/YamlDotNet.asmdef
+++ b/Packages/UGF.Yaml/Runtime/Plugins/YamlDotNet/YamlDotNet.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "YamlDotNet",
+    "rootNamespace": "YamlDotNet",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Yaml/Runtime/UGF.Yaml.Runtime.asmdef
+++ b/Packages/UGF.Yaml/Runtime/UGF.Yaml.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UGF.Yaml.Runtime",
+    "rootNamespace": "UGF.Yaml.Runtime",
     "references": [
         "GUID:5bd6d7319b96dab4b887fb59cd3ad7b7"
     ],

--- a/Packages/UGF.Yaml/Runtime/YamlUtility.cs
+++ b/Packages/UGF.Yaml/Runtime/YamlUtility.cs
@@ -6,18 +6,21 @@ namespace UGF.Yaml.Runtime
 {
     public static class YamlUtility
     {
-        private static readonly ISerializer m_serializer;
-        private static readonly IDeserializer m_deserializer;
+        public static ISerializer DefaultSerializer { get; } = CreateDefaultSerializer();
+        public static IDeserializer DefaultDeserializer { get; } = CreateDefaultDeserializer();
 
-        static YamlUtility()
+        public static ISerializer CreateDefaultSerializer()
         {
-            m_serializer = new SerializerBuilder()
+            return new SerializerBuilder()
                 .DisableAliases()
                 .EmitDefaults()
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
+        }
 
-            m_deserializer = new DeserializerBuilder()
+        public static IDeserializer CreateDefaultDeserializer()
+        {
+            return new DeserializerBuilder()
                 .IgnoreUnmatchedProperties()
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
@@ -27,7 +30,7 @@ namespace UGF.Yaml.Runtime
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
 
-            return m_serializer.Serialize(target);
+            return DefaultSerializer.Serialize(target);
         }
 
         public static object FromYaml(string text, Type type)
@@ -35,14 +38,14 @@ namespace UGF.Yaml.Runtime
             if (string.IsNullOrEmpty(text)) throw new ArgumentException("Value cannot be null or empty.", nameof(text));
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            return m_deserializer.Deserialize(text, type);
+            return DefaultDeserializer.Deserialize(text, type);
         }
 
         public static T FromYaml<T>(string text)
         {
             if (string.IsNullOrEmpty(text)) throw new ArgumentException("Value cannot be null or empty.", nameof(text));
 
-            return m_deserializer.Deserialize<T>(text);
+            return DefaultDeserializer.Deserialize<T>(text);
         }
     }
 }

--- a/Packages/UGF.Yaml/Runtime/YamlUtility.cs
+++ b/Packages/UGF.Yaml/Runtime/YamlUtility.cs
@@ -6,24 +6,22 @@ namespace UGF.Yaml.Runtime
 {
     public static class YamlUtility
     {
-        public static ISerializer DefaultSerializer { get; } = CreateDefaultSerializer();
-        public static IDeserializer DefaultDeserializer { get; } = CreateDefaultDeserializer();
+        public static ISerializer DefaultSerializer { get; } = CreateDefaultSerializerBuilder().Build();
+        public static IDeserializer DefaultDeserializer { get; } = CreateDefaultDeserializerBuilder().Build();
 
-        public static ISerializer CreateDefaultSerializer()
+        public static SerializerBuilder CreateDefaultSerializerBuilder()
         {
             return new SerializerBuilder()
                 .DisableAliases()
                 .EmitDefaults()
-                .WithNamingConvention(new CamelCaseNamingConvention())
-                .Build();
+                .WithNamingConvention(new CamelCaseNamingConvention());
         }
 
-        public static IDeserializer CreateDefaultDeserializer()
+        public static DeserializerBuilder CreateDefaultDeserializerBuilder()
         {
             return new DeserializerBuilder()
                 .IgnoreUnmatchedProperties()
-                .WithNamingConvention(new CamelCaseNamingConvention())
-                .Build();
+                .WithNamingConvention(new CamelCaseNamingConvention());
         }
 
         public static string ToYaml(object target)

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.test-framework": "1.1.16"
+    "com.unity.ide.rider": "3.0.3",
+    "com.unity.test-framework": "1.1.20"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,14 +7,14 @@
       "dependencies": {}
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "2.0.7",
+      "version": "3.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -23,11 +23,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.16",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.1.5f1
-m_EditorVersionWithRevision: 2020.1.5f1 (e025938fdedc)
+m_EditorVersion: 2020.2.0f1
+m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)


### PR DESCRIPTION
- Add `YamlUtility.CreateDefaultSerializerBuilder` and `CreateDefaultDeserializerBuilder` methods to create serializer and deserializer builder with default properties.
- Add `DefaultSerializer` and `DefaultDeserializer` properties with default serializer and deserializer.