### PR TITLE
Change properties serialization order of inherited members

### DIFF
--- a/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceCountComparer.cs
+++ b/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceCountComparer.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using YamlDotNet.Serialization;
+
+namespace UGF.Yaml.Runtime
+{
+    public class YamlPropertyInheritanceCountComparer : IComparer<IPropertyDescriptor>
+    {
+        public Type ContainerType { get; }
+
+        public YamlPropertyInheritanceCountComparer(Type containerType)
+        {
+            ContainerType = containerType ?? throw new ArgumentNullException(nameof(containerType));
+        }
+
+        public int Compare(IPropertyDescriptor x, IPropertyDescriptor y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (ReferenceEquals(null, y)) return 1;
+            if (ReferenceEquals(null, x)) return -1;
+
+            Type xDeclaringType = GetDeclaringType(ContainerType, x);
+            Type yDeclaringType = GetDeclaringType(ContainerType, y);
+
+            int xCount = GetInheritanceCount(xDeclaringType);
+            int yCount = GetInheritanceCount(yDeclaringType);
+
+            return xCount.CompareTo(yCount);
+        }
+
+        private static Type GetDeclaringType(Type containerType, IPropertyDescriptor propertyDescriptor)
+        {
+            if (propertyDescriptor == null) throw new ArgumentNullException(nameof(propertyDescriptor));
+
+            MemberInfo[] members = containerType.GetMember(propertyDescriptor.Name, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+            if (members.Length == 0) throw new ArgumentException($"Members not found by the specified name: '{propertyDescriptor.Name}'.");
+
+            MemberInfo member = members[0];
+
+            return member.DeclaringType;
+        }
+
+        private static int GetInheritanceCount(Type type)
+        {
+            int count = 0;
+
+            while (type != null)
+            {
+                count++;
+
+                type = type.BaseType;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceCountComparer.cs.meta
+++ b/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceCountComparer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94be9e5f536b4c07a131f6aa5c2c0a07
+timeCreated: 1608575322

--- a/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceOrderTypeInspector.cs
+++ b/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceOrderTypeInspector.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.TypeInspectors;
+
+namespace UGF.Yaml.Runtime
+{
+    public class YamlPropertyInheritanceOrderTypeInspector : TypeInspectorSkeleton
+    {
+        public ITypeInspector InnerInspector { get; }
+
+        public YamlPropertyInheritanceOrderTypeInspector(ITypeInspector innerInspector)
+        {
+            InnerInspector = innerInspector ?? throw new ArgumentNullException(nameof(innerInspector));
+        }
+
+        public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+        {
+            var properties = new List<IPropertyDescriptor>(InnerInspector.GetProperties(type, container));
+            var comparer = new YamlPropertyInheritanceCountComparer(type);
+
+            properties.Sort(comparer);
+
+            return properties;
+        }
+    }
+}

--- a/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceOrderTypeInspector.cs.meta
+++ b/Packages/UGF.Yaml/Runtime/YamlPropertyInheritanceOrderTypeInspector.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 377ab6d00a834ec38920d5f4d5e8b896
+timeCreated: 1608575862

--- a/Packages/UGF.Yaml/Runtime/YamlUtility.cs
+++ b/Packages/UGF.Yaml/Runtime/YamlUtility.cs
@@ -14,7 +14,8 @@ namespace UGF.Yaml.Runtime
             return new SerializerBuilder()
                 .DisableAliases()
                 .EmitDefaults()
-                .WithNamingConvention(new CamelCaseNamingConvention());
+                .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeInspector<ITypeInspector>(inspector => new YamlPropertyInheritanceOrderTypeInspector(inspector), syntax => syntax.OnBottom());
         }
 
         public static DeserializerBuilder CreateDefaultDeserializerBuilder()


### PR DESCRIPTION
- Add `YamlPropertyInheritanceCountComparer` and `YamlPropertyInheritanceOrderTypeInspector ` used to sort serialized properties depending on inheritance.
- Change `YamlUtility.CreateDefaultSerializerBuilder` to use `YamlPropertyInheritanceOrderTypeInspector` and sort properties by default.